### PR TITLE
Fix Vercel deployment: resolve module alias issues

### DIFF
--- a/app/tsconfig.json
+++ b/app/tsconfig.json
@@ -1,0 +1,43 @@
+{
+  "compilerOptions": {
+    "target": "es2020",
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "es5",
+      "es2020"
+    ],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "baseUrl": ".",
+    "paths": {
+      "@/*": [
+        "./*"
+      ]
+    }
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    ".build/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}


### PR DESCRIPTION
## 🐛 Fix Vercel Deployment Issues

### Problem
Vercel deployment was failing with multiple "Module not found" errors for components using `@/` aliases:
- `@/components/cookie-banner`
- `@/components/services-section` 
- `@/components/lead-magnet`
- `@/components/testimonials-section`
- `@/components/blog-preview`

### Root Cause
The `tsconfig.json` was missing the `baseUrl` property, which is required for proper module resolution on Vercel's build environment.

### Solution
✅ Added `"baseUrl": "."` to `tsconfig.json`
✅ Verified all components exist in the correct locations
✅ Tested local build - now compiles successfully
✅ Ready for Vercel deployment

### Files Changed
- `app/tsconfig.json` - Added baseUrl for proper alias resolution

### Testing
- ✅ Local build passes: `npm run build` 
- ✅ All components resolve correctly
- ✅ No TypeScript errors

This fix ensures the project will deploy successfully on Vercel without module resolution errors.