### PR TITLE
🔧 Fix Vercel "Function Runtimes must have a valid version" error

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,19 +1,14 @@
-const path = require('path');
-
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  distDir: process.env.NEXT_DIST_DIR || '.next',
-  output: process.env.NEXT_OUTPUT_MODE,
-  experimental: {
-    outputFileTracingRoot: path.join(__dirname, '../'),
-  },
   eslint: {
     ignoreDuringBuilds: true,
   },
   typescript: {
     ignoreBuildErrors: false,
   },
-  images: { unoptimized: true },
+  images: { 
+    unoptimized: true 
+  },
 };
 
 module.exports = nextConfig;


### PR DESCRIPTION
## 🎯 Objectif
Corriger l'erreur Vercel "Function Runtimes must have a valid version" qui empêche le déploiement du site "La Clé du Prêt".

## 🔍 Problème identifié
L'erreur provenait de configurations problématiques dans `next.config.js` :
- `output: process.env.NEXT_OUTPUT_MODE` - Variable d'environnement non définie ou invalide
- `distDir: process.env.NEXT_DIST_DIR || '.next'` - Configuration inutile pour Vercel
- `experimental.outputFileTracingRoot` - Peut causer des conflits avec Vercel

## ✅ Solution appliquée
- **Nettoyage complet** du fichier `next.config.js`
- **Suppression** des configurations problématiques
- **Conservation** uniquement des configurations essentielles :
  - `eslint.ignoreDuringBuilds: true`
  - `typescript.ignoreBuildErrors: false`
  - `images.unoptimized: true`

## 🚀 Résultat attendu
- ✅ Élimination de l'erreur "Function Runtimes must have a valid version"
- ✅ Déploiement Vercel réussi
- ✅ Site "La Clé du Prêt" accessible en ligne

## 🔄 Déploiement automatique
Une fois cette PR fusionnée, Vercel déclenchera automatiquement un nouveau déploiement avec la configuration corrigée.

---
**Prêt pour fusion et déploiement ! 🎉**